### PR TITLE
Non-Personal Multireddit Support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "description": "Auto-refresh and visual highlight of changes on reddit post pages",
   "homepage_url": "https://github.com/mrspeaker/whats-new-reddit",
   "content_scripts": [{
-    "matches": ["https://www.reddit.com/r/*", "https://www.reddit.com/"],
+    "matches": ["https://www.reddit.com/r/*", "https://www.reddit.com/", "https://www.reddit.com/*/m/*"],
     "js": ["Settings.js", "whats-new-reddit.js"],
     "css": ["styles.css"]
   }],

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "description": "Auto-refresh and visual highlight of changes on reddit post pages",
   "homepage_url": "https://github.com/mrspeaker/whats-new-reddit",
   "content_scripts": [{
-    "matches": ["https://www.reddit.com/r/*", "https://www.reddit.com/", "https://www.reddit.com/*/m/*"],
+    "matches": ["https://www.reddit.com/r/*", "https://www.reddit.com/", "https://www.reddit.com/user/*/m/*"],
     "js": ["Settings.js", "whats-new-reddit.js"],
     "css": ["styles.css"]
   }],


### PR DESCRIPTION
With this `https://www.reddit.com/user/*/m/*` multireddit pages will also work with this extension.

I was trying to get my personal multireddits to work with this but kept on running into the issue where `https://www.reddit.com/me/m/*` would pull from _r/all_ instead and I couldn't figure out a way to get it to pull from `https://www.reddit.com/user/flagrama/m/*` even after marking it public as Reddit always redirects _/user/YourUserName_ to _/me_ and my extension javascript and debugging skills are weak.

I can just use an alternative method of grouping subreddits together right now that works but is just annoying to do, so I'd appreciate it if you'd look into this further in the future.